### PR TITLE
Update template-quickstart-nodejs.md

### DIFF
--- a/template-quickstart-nodejs.md
+++ b/template-quickstart-nodejs.md
@@ -102,7 +102,7 @@ Create variables for your resource's Azure endpoint and key. If you created the 
 Install the `ms-rest-azure` and `azure-cognitiveservices-[Product Name]` NPM packages:
 
 ```console
-npm install azure-cognitiveservices-[Product Name] ms-rest-azure
+npm install azure-cognitiveservices-[Product Name] ms-rest-azure --save
 ```
 
 Your app's `package.json` file will be updated with the dependencies.


### PR DESCRIPTION
The dependencies are only saved to the package.json if you use the --save switch.